### PR TITLE
Replace deprecated openURL

### DIFF
--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -28,19 +28,21 @@
             } else {
               iTunesLink = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@", appId];
             }
-            
+
             if ([call.arguments[@"is_ios_beta"] boolValue]) {
               NSURL *customAppURL = [NSURL URLWithString:@"itms-beta://"];
               if ([[UIApplication sharedApplication] canOpenURL:customAppURL]) {
-                  
+
                   // TestFlight is installed
-                  
+
                   // Special link that includes the app's Apple ID
                   iTunesLink = [NSString stringWithFormat:@"itms-beta://beta.itunes.apple.com/v1/app/id%@", appId];
                   NSURL* itunesURL = [NSURL URLWithString:iTunesLink];
 
                   if ([[UIApplication sharedApplication] canOpenURL:itunesURL]) {
-                    [[UIApplication sharedApplication] openURL:itunesURL];
+                    [[UIApplication sharedApplication] openURL:itunesURL
+                                                       options:@{}
+                                             completionHandler:nil];
                   }
                   result(nil);
               }
@@ -48,7 +50,13 @@
 
             NSURL* itunesURL = [NSURL URLWithString:iTunesLink];
             if ([[UIApplication sharedApplication] canOpenURL:itunesURL]) {
-              [[UIApplication sharedApplication] openURL:itunesURL];
+              [[UIApplication sharedApplication] openURL:itunesURL
+                                                 options:@{}
+                                       completionHandler:^(BOOL success) {
+                  if (!success) {
+                      NSLog(@"Failed to open URL: %@", itunesURL);
+                  }
+              }];
             }
 
             result(nil);


### PR DESCRIPTION
After deploying from Xcode 16, the `LaunchReview.launch` functionality stopped working.

The following error message is displayed:
BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).

To address this, I have replaced `UIApplication.openURL(_:)` with the non-deprecated `openURL:options:completionHandler:`, ensuring compatibility with devices running iOS 10 and later.

Key changes:
- Replaced `UIApplication.openURL(_:)` with `openURL:options:completionHandler:`.
- Added a `completionHandler` to verify whether the URL was successfully opened.

This fix resolves the compatibility issue when deploying with Xcode 16 or later.
